### PR TITLE
Also symlink javap to /usr/bin

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -15,9 +15,11 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javap /usr/bin/javap && \
 	# The dual version command is to support OpenJDK 8
 	java --version || java -version && \
 	javac --version || javac -version
+	javap --version || javap -version
 
 ENV MAVEN_VERSION=3.6.3 \
 	PATH=/opt/apache-maven/bin:$PATH

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -15,9 +15,11 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javap /usr/bin/javap && \
 	# The dual version command is to support OpenJDK 8
 	java --version || java -version && \
 	javac --version || javac -version
+	javap --version || javap -version
 
 ENV MAVEN_VERSION=3.6.3 \
 	PATH=/opt/apache-maven/bin:$PATH

--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -15,9 +15,11 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javap /usr/bin/javap && \
 	# The dual version command is to support OpenJDK 8
 	java --version || java -version && \
 	javac --version || javac -version
+	javap --version || javap -version
 
 ENV MAVEN_VERSION=3.6.3 \
 	PATH=/opt/apache-maven/bin:$PATH

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -15,9 +15,11 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javap /usr/bin/javap && \
 	# The dual version command is to support OpenJDK 8
 	java --version || java -version && \
 	javac --version || javac -version
+	javap --version || javap -version
 
 ENV MAVEN_VERSION=3.6.3 \
 	PATH=/opt/apache-maven/bin:$PATH


### PR DESCRIPTION
This pull request updates Dockerfiles so they also symlink ``javap`` binary to ``/usr/bin/``.

Without doing that, the user needs to know inner workings / implementation details / directory structure of those Docker images if they wish to use ``javap`` (they need to inspect Dockerfile to see into which directory openjdk gets installed or similar).