### PR TITLE
Add Dockerfile for OpenJDK 15

### DIFF
--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -1,0 +1,38 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/base:2020.06
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV JAVA_VERSION 15.0.0
+ENV URL https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15%2B36/OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz
+ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}
+
+RUN curl -sSL -o java.tar.gz "${URL}" && \
+	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \
+	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \
+	rm java.tar.gz && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	# The dual version command is to support OpenJDK 8
+	java --version || java -version && \
+	javac --version || javac -version
+
+ENV MAVEN_VERSION=3.6.3 \
+	PATH=/opt/apache-maven/bin:$PATH
+RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+	curl -sSL --fail --retry 3 $dl_URL -o apache-maven.tar.gz && \
+	sudo tar -xzf apache-maven.tar.gz -C /opt/ && \
+	rm apache-maven.tar.gz && \
+	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
+	mvn --version
+
+ENV GRADLE_VERSION=6.2.2 \
+	PATH=/opt/gradle/bin:$PATH
+RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
+	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
+	sudo unzip -d /opt gradle.zip && \
+	rm gradle.zip && \
+	sudo ln -s /opt/gradle-* /opt/gradle && \
+	gradle --version


### PR DESCRIPTION
This PR adds `Dockerfile` for OpenJDK 15. This is based on the `Dockerfile` for OpenJDK 14 and updates only stuff related to JDK version.

See https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/tag/jdk-15%2B36