### PR TITLE
Update README for for dev-hub parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ For example:
 jobs:
   build:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:15.0
     steps:
       - checkout
       - run: java --version
 ```
 
 In the above example, the CircleCI OpenJDK Docker image is used for the primary container.
-More specifically, the tag `11.0` is used meaning the version of OpenJDK will be v11.0.
+More specifically, the tag `15.0` is used meaning the version of OpenJDK will be v15.0.0.
 You can now use OpenJDK within the steps for this job.
 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
 ```
 
 In the above example, the CircleCI OpenJDK Docker image is used for the primary container.
-More specifically, the tag `11.0` is used meaning the version of OpenJDK will be v11.0.x where 'x' is the latest patch release.
+More specifically, the tag `11.0` is used meaning the version of OpenJDK will be v11.0.
 You can now use OpenJDK within the steps for this job.
 
 


### PR DESCRIPTION
In the dev-hub we are going to automatically sync the content from the cimg READMEs.
As a part of the copy in the dev-hub, the semantic versions in the Getting Started header are going to be updated to the latest tag.

https://circleci.com/developer/images/image/cimg/openjdk
Currently, the sample config is updated with the latest version semver, but the description below it mentions the text here.
As we automatically sync the content, we're simply going to update the semver in the entire header. This change makes the content in the header make more sense.
The explanation of the semver tags is in the Tagging Scheme header.