### PR TITLE
Java Fixed Locations

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-11 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-16 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-8 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \


### PR DESCRIPTION
Make it simpler for tools like Maven ToolChain that prefer static locations so are not hard coded to specific releases.

Not touched 13, 14 or 15 as they are no longer in support.