### PR TITLE
Java LTS versions

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-11 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-16 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -18,6 +18,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-8 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \

--- a/build-images.sh
+++ b/build-images.sh
@@ -9,3 +9,6 @@ docker build --file 11.0/browsers/Dockerfile -t cimg/openjdk:11.0.12-browsers  -
 docker build --file 17.0/Dockerfile -t cimg/openjdk:17.0.0  -t cimg/openjdk:17.0 .
 docker build --file 17.0/node/Dockerfile -t cimg/openjdk:17.0.0-node  -t cimg/openjdk:17.0-node .
 docker build --file 17.0/browsers/Dockerfile -t cimg/openjdk:17.0.0-browsers  -t cimg/openjdk:17.0-browsers .
+docker build --file lts/Dockerfile -t cimg/openjdk:lts-8.0.302-11.0.12  -t cimg/openjdk:lts-8-11 .
+docker build --file lts/node/Dockerfile -t cimg/openjdk:lts-8.0.302-11.0.12-node  -t cimg/openjdk:lts-8-11-node .
+docker build --file lts/browsers/Dockerfile -t cimg/openjdk:lts-8.0.302-11.0.12-browsers  -t cimg/openjdk:8-11-browsers .

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,6 +3,9 @@
 docker build --file 8.0/Dockerfile -t cimg/openjdk:8.0.302  -t cimg/openjdk:8.0 .
 docker build --file 8.0/node/Dockerfile -t cimg/openjdk:8.0.302-node  -t cimg/openjdk:8.0-node .
 docker build --file 8.0/browsers/Dockerfile -t cimg/openjdk:8.0.302-browsers  -t cimg/openjdk:8.0-browsers .
+docker build --file 11.0/Dockerfile -t cimg/openjdk:11.0.12  -t cimg/openjdk:11.0 .
+docker build --file 11.0/node/Dockerfile -t cimg/openjdk:11.0.12-node  -t cimg/openjdk:11.0-node .
+docker build --file 11.0/browsers/Dockerfile -t cimg/openjdk:11.0.12-browsers  -t cimg/openjdk:11.0-browsers .
 docker build --file 17.0/Dockerfile -t cimg/openjdk:17.0.0  -t cimg/openjdk:17.0 .
 docker build --file 17.0/node/Dockerfile -t cimg/openjdk:17.0.0-node  -t cimg/openjdk:17.0-node .
 docker build --file 17.0/browsers/Dockerfile -t cimg/openjdk:17.0.0-browsers  -t cimg/openjdk:17.0-browsers .

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -1,0 +1,52 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/base:2021.03
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV JAVA8_VERSION 8.0.282
+ENV JAVA8_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz
+
+ENV JAVA_VERSION 11.0.10
+ENV URL https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz
+ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}
+
+RUN curl -sSL -o java.tar.gz "${JAVA8_URL}" && \
+	sudo mkdir /usr/local/jdk-${JAVA8_VERSION} && \
+	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA8_VERSION} && \
+	rm java.tar.gz && \
+	sudo ln -s /usr/local/jdk-${JAVA8_VERSION} /usr/local/openjdk-8 && \
+	curl -sSL -o java.tar.gz "${URL}" && \
+	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \
+	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \
+	rm java.tar.gz && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-11 && \
+	# Install packages to help with legacy image migration
+	sudo apt-get update && sudo apt-get install -y \
+		fontconfig \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+	# The dual version command is to support OpenJDK 8
+	java --version || java -version && \
+	javac --version || javac -version
+
+ENV MAVEN_VERSION=3.6.3 \
+	PATH=/opt/apache-maven/bin:$PATH
+RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+	curl -sSL --fail --retry 3 $dl_URL -o apache-maven.tar.gz && \
+	sudo tar -xzf apache-maven.tar.gz -C /opt/ && \
+	rm apache-maven.tar.gz && \
+	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
+	mvn --version
+
+ENV GRADLE_VERSION=6.8.3 \
+	PATH=/opt/gradle/bin:$PATH
+RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
+	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
+	sudo unzip -d /opt gradle.zip && \
+	rm gradle.zip && \
+	sudo ln -s /opt/gradle-* /opt/gradle && \
+	gradle --version

--- a/lts/browsers/Dockerfile
+++ b/lts/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/openjdk:lts-8.0.282-11.0.10-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/lts/node/Dockerfile
+++ b/lts/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/openjdk:lts-8.0.282-11.0.10
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg


### PR DESCRIPTION
Have both Java 1.8 and 11 installed, some projects might need this more and more as they transition from Java 1.8, to 11 and beyond.

Not sure if worked correctly, and another image stream might be useful to have 1.8, 11 and the latest currently 16, maybe also with 17-ea.
When when 17 LTS is released, it would have 17 added and 18-ea.