### PR TITLE
Fixed JAVA_HOME env var

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 
 ENV JAVA_VERSION 11.0.12
 ENV URL https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz
-ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}
+ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}/bin/java
 
 RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \


### PR DESCRIPTION
JAVA_HOME env var was not set properly for ` cimg/openjdk:11.0.0`. 