### PR TITLE
added symlink for major versions

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -12,6 +12,10 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \
 	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \
 	rm java.tar.gz && \
+		if [[ "$JAVA_VERSION" == *"0.0"* ]]; then \
+			sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/jdk-%%VERSION_MAJOR%%; \
+		fi && \
+\
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \


### PR DESCRIPTION
JAVA_HOME is pointing to wrong value for major versions. Created symlink to fix issue. 