### PR TITLE
Respin LTSs and v16 for log4j security fix [release]

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -36,7 +36,7 @@ RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/ap
 	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
 	mvn --version
 
-ENV GRADLE_VERSION=7.2 \
+ENV GRADLE_VERSION=7.3.2 \
 	PATH=/opt/gradle/bin:$PATH
 RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
 	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
@@ -45,7 +45,7 @@ RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-b
 	sudo ln -s /opt/gradle-* /opt/gradle && \
 	gradle --version
 
-ENV SBT_VERSION=1.5.5 \
+ENV SBT_VERSION=1.5.7 \
 	PATH=/opt/sbt/bin:$PATH
 RUN dl_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o sbt.tar.gz && \

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.07
+FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -27,7 +27,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	java --version || java -version && \
 	javac --version || javac -version
 
-ENV MAVEN_VERSION=3.8.2 \
+ENV MAVEN_VERSION=3.8.4 \
 	PATH=/opt/apache-maven/bin:$PATH
 RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o apache-maven.tar.gz && \
@@ -36,7 +36,7 @@ RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/ap
 	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
 	mvn --version
 
-ENV GRADLE_VERSION=7.2 \
+ENV GRADLE_VERSION=7.3.2 \
 	PATH=/opt/gradle/bin:$PATH
 RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
 	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
@@ -45,7 +45,7 @@ RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-b
 	sudo ln -s /opt/gradle-* /opt/gradle && \
 	gradle --version
 
-ENV SBT_VERSION=1.5.5 \
+ENV SBT_VERSION=1.5.7 \
 	PATH=/opt/sbt/bin:$PATH
 RUN dl_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o sbt.tar.gz && \

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -36,7 +36,7 @@ RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/ap
 	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
 	mvn --version
 
-ENV GRADLE_VERSION=7.2 \
+ENV GRADLE_VERSION=7.3.2 \
 	PATH=/opt/gradle/bin:$PATH
 RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
 	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
@@ -45,7 +45,7 @@ RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-b
 	sudo ln -s /opt/gradle-* /opt/gradle && \
 	gradle --version
 
-ENV SBT_VERSION=1.5.5 \
+ENV SBT_VERSION=1.5.7 \
 	PATH=/opt/sbt/bin:$PATH
 RUN dl_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o sbt.tar.gz && \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -36,7 +36,7 @@ RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/ap
 	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
 	mvn --version
 
-ENV GRADLE_VERSION=7.2 \
+ENV GRADLE_VERSION=7.3.2 \
 	PATH=/opt/gradle/bin:$PATH
 RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
 	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
@@ -45,7 +45,7 @@ RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-b
 	sudo ln -s /opt/gradle-* /opt/gradle && \
 	gradle --version
 
-ENV SBT_VERSION=1.5.5 \
+ENV SBT_VERSION=1.5.7 \
 	PATH=/opt/sbt/bin:$PATH
 RUN dl_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o sbt.tar.gz && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -36,7 +36,7 @@ RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/ap
 	sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
 	mvn --version
 
-ENV GRADLE_VERSION=7.2 \
+ENV GRADLE_VERSION=7.3.2 \
 	PATH=/opt/gradle/bin:$PATH
 RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
 	curl -sSL --fail --retry 3 $dl_URL -o gradle.zip && \
@@ -45,7 +45,7 @@ RUN dl_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-b
 	sudo ln -s /opt/gradle-* /opt/gradle && \
 	gradle --version
 
-ENV SBT_VERSION=1.5.5 \
+ENV SBT_VERSION=1.5.7 \
 	PATH=/opt/sbt/bin:$PATH
 RUN dl_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o sbt.tar.gz && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -6,3 +6,9 @@ docker build --file 8.0/browsers/Dockerfile -t cimg/openjdk:8.0.312-browsers  -t
 docker build --file 11.0/Dockerfile -t cimg/openjdk:11.0.13  -t cimg/openjdk:11.0 .
 docker build --file 11.0/node/Dockerfile -t cimg/openjdk:11.0.13-node  -t cimg/openjdk:11.0-node .
 docker build --file 11.0/browsers/Dockerfile -t cimg/openjdk:11.0.13-browsers  -t cimg/openjdk:11.0-browsers .
+docker build --file 16.0/Dockerfile -t cimg/openjdk:16.0.2  -t cimg/openjdk:16.0 .
+docker build --file 16.0/node/Dockerfile -t cimg/openjdk:16.0.2-node  -t cimg/openjdk:16.0-node .
+docker build --file 16.0/browsers/Dockerfile -t cimg/openjdk:16.0.2-browsers  -t cimg/openjdk:16.0-browsers .
+docker build --file 17.0/Dockerfile -t cimg/openjdk:17.0.1  -t cimg/openjdk:17.0 .
+docker build --file 17.0/node/Dockerfile -t cimg/openjdk:17.0.1-node  -t cimg/openjdk:17.0-node .
+docker build --file 17.0/browsers/Dockerfile -t cimg/openjdk:17.0.1-browsers  -t cimg/openjdk:17.0-browsers .


### PR DESCRIPTION
Respinning all supported releases of OpenJDK (just the latest patch versions) due to the log4j CVE. This updates SBT and Gradle, which includes fixes. Some non-recent releases such as v8 and v16 will get a base image update and/or Maven update as well.