### PR TITLE
updates gen-dockerfile files and generates gen-check

### DIFF
--- a/11.0/browsers/Dockerfile
+++ b/11.0/browsers/Dockerfile
@@ -18,34 +18,6 @@ RUN sudo apt-get update && \
         echo "Java not found in parent image, installing..." && \
         sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
     fi && \
-
-    # Firefox deps
-    sudo apt-get install -y --no-install-recommends --no-upgrade \
-		libdbus-glib-1-2 \
-		libgtk-3-dev \
-		libxt6 \
-	&& \
-
-    # Google Chrome deps
-	# Some of these packages should be pulled into their own section
-    sudo apt-get install -y --no-install-recommends --no-upgrade \
-        fonts-liberation \
-        libappindicator3-1 \
-        libasound2 \
-        libatk-bridge2.0-0 \
-        libatspi2.0-0 \
-        libcairo2 \
-        libcups2 \
-        libgbm1 \
-        libgdk-pixbuf2.0-0 \
-        libgtk-3-0 \
-        libpango-1.0-0 \
-        libpangocairo-1.0-0 \
-        libxcursor1 \
-		libxss1 \
-        xdg-utils \
-		xvfb \
-	&& \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Below is setup to allow xvfb to start when the container starts up.
@@ -58,6 +30,34 @@ ENV DISPLAY=":99"
 #	sudo mv /tmp/entrypoint /docker-entrypoint.sh
 RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
 	sudo chmod +x /docker-entrypoint.sh
+
+# Install a single version of Firefox. This isn't intended to be a regularly
+# updated thing. Instead, if this version of Firefox isn't want the end user
+# wants they should install a different version via the Browser Tools Orb.
+#
+# Canonical made a major technology change in how Firefox is installed from
+# Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
+# based Firefox right now so we are installing the original deb based version
+# from Ubuntu Focal, even if the current Ubuntu version is newer.
+RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main' | sudo tee /etc/apt/sources.list.d/firefox.list && \
+	echo 'Package: firefox' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release n=focal' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+
+	sudo apt-get update && \
+	sudo apt-get install --no-install-recommends --yes firefox && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	firefox --version
+
+# Install a single version of Google Chrome Stable. This isn't intended to be a
+# regularly updated thing. Instead, if this version of Chrome isn't want the
+# end user wants they should install a different version via the Browser Tools
+# Orb.
+RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+	sudo apt-get update && \
+	sudo apt-get install google-chrome-stable && \
+	sudo rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/bin/sh"]

--- a/11.0/node/Dockerfile
+++ b/11.0/node/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/8.0/browsers/Dockerfile
+++ b/8.0/browsers/Dockerfile
@@ -18,34 +18,6 @@ RUN sudo apt-get update && \
         echo "Java not found in parent image, installing..." && \
         sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
     fi && \
-
-    # Firefox deps
-    sudo apt-get install -y --no-install-recommends --no-upgrade \
-		libdbus-glib-1-2 \
-		libgtk-3-dev \
-		libxt6 \
-	&& \
-
-    # Google Chrome deps
-	# Some of these packages should be pulled into their own section
-    sudo apt-get install -y --no-install-recommends --no-upgrade \
-        fonts-liberation \
-        libappindicator3-1 \
-        libasound2 \
-        libatk-bridge2.0-0 \
-        libatspi2.0-0 \
-        libcairo2 \
-        libcups2 \
-        libgbm1 \
-        libgdk-pixbuf2.0-0 \
-        libgtk-3-0 \
-        libpango-1.0-0 \
-        libpangocairo-1.0-0 \
-        libxcursor1 \
-		libxss1 \
-        xdg-utils \
-		xvfb \
-	&& \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Below is setup to allow xvfb to start when the container starts up.
@@ -58,6 +30,34 @@ ENV DISPLAY=":99"
 #	sudo mv /tmp/entrypoint /docker-entrypoint.sh
 RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
 	sudo chmod +x /docker-entrypoint.sh
+
+# Install a single version of Firefox. This isn't intended to be a regularly
+# updated thing. Instead, if this version of Firefox isn't want the end user
+# wants they should install a different version via the Browser Tools Orb.
+#
+# Canonical made a major technology change in how Firefox is installed from
+# Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
+# based Firefox right now so we are installing the original deb based version
+# from Ubuntu Focal, even if the current Ubuntu version is newer.
+RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main' | sudo tee /etc/apt/sources.list.d/firefox.list && \
+	echo 'Package: firefox' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release n=focal' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+
+	sudo apt-get update && \
+	sudo apt-get install --no-install-recommends --yes firefox && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	firefox --version
+
+# Install a single version of Google Chrome Stable. This isn't intended to be a
+# regularly updated thing. Instead, if this version of Chrome isn't want the
+# end user wants they should install a different version via the Browser Tools
+# Orb.
+RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+	sudo apt-get update && \
+	sudo apt-get install google-chrome-stable && \
+	sudo rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/bin/sh"]

--- a/8.0/node/Dockerfile
+++ b/8.0/node/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.18
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,0 +1,1 @@
+GEN_CHECK=(8.0.345#https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz 11.0.16#https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.16_8.tar.gz)

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 8.0/Dockerfile -t cimg/openjdk:8.0.345  -t cimg/openjdk:8.0 .
-docker build --file 8.0/node/Dockerfile -t cimg/openjdk:8.0.345-node  -t cimg/openjdk:8.0-node .
-docker build --file 8.0/browsers/Dockerfile -t cimg/openjdk:8.0.345-browsers  -t cimg/openjdk:8.0-browsers .
-docker build --file 11.0/Dockerfile -t cimg/openjdk:11.0.16  -t cimg/openjdk:11.0 .
-docker build --file 11.0/node/Dockerfile -t cimg/openjdk:11.0.16-node  -t cimg/openjdk:11.0-node .
-docker build --file 11.0/browsers/Dockerfile -t cimg/openjdk:11.0.16-browsers  -t cimg/openjdk:11.0-browsers .
+docker build --file 8.0/Dockerfile -t cimg/openjdk:8.0.345 -t cimg/openjdk:8.0 .
+docker build --file 8.0/node/Dockerfile -t cimg/openjdk:8.0.345-node -t cimg/openjdk:8.0-node .
+docker build --file 8.0/browsers/Dockerfile -t cimg/openjdk:8.0.345-browsers -t cimg/openjdk:8.0-browsers .
+docker build --file 11.0/Dockerfile -t cimg/openjdk:11.0.16 -t cimg/openjdk:11.0 .
+docker build --file 11.0/node/Dockerfile -t cimg/openjdk:11.0.16-node -t cimg/openjdk:11.0-node .
+docker build --file 11.0/browsers/Dockerfile -t cimg/openjdk:11.0.16-browsers -t cimg/openjdk:11.0-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
-
-docker push cimg/openjdk:8.0.345
 docker push cimg/openjdk:8.0
-docker push cimg/openjdk:8.0.345-node
+docker push cimg/openjdk:8.0.345
 docker push cimg/openjdk:8.0-node
-docker push cimg/openjdk:8.0.345-browsers
+docker push cimg/openjdk:8.0.345-node
 docker push cimg/openjdk:8.0-browsers
-
-docker push cimg/openjdk:11.0.16
+docker push cimg/openjdk:8.0.345-browsers
 docker push cimg/openjdk:11.0
-docker push cimg/openjdk:11.0.16-node
+docker push cimg/openjdk:11.0.16
 docker push cimg/openjdk:11.0-node
-docker push cimg/openjdk:11.0.16-browsers
+docker push cimg/openjdk:11.0.16-node
 docker push cimg/openjdk:11.0-browsers
+docker push cimg/openjdk:11.0.16-browsers


### PR DESCRIPTION
since there was a change to cimg-shared, this updates the dockerfiles but does not publish

it should be noted that the dockerfiles in this PR will be reflected in the next release

edit: more importantly, the generated file gen-check allows for the cimg-orb to check the validity of the dockerfiles