### PR TITLE
Respin v19.0.1. [release]

### DIFF
--- a/19.0/Dockerfile
+++ b/19.0/Dockerfile
@@ -5,7 +5,9 @@
 # By policy, the base image tag should be a quarterly tag unless there's a 
 # specific reason to use a different one. This means January, April, July, or 
 # October.
-FROM cimg/base:2022.10
+
+# NOTE: This release uses the November image due to an OpenSSL CVE. We will resume using quarterly images in Q1
+FROM cimg/base:2022.11
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,9 @@
 # By policy, the base image tag should be a quarterly tag unless there's a 
 # specific reason to use a different one. This means January, April, July, or 
 # October.
-FROM cimg/%%PARENT%%:2022.10
+
+# NOTE: This release uses the November image due to an OpenSSL CVE. We will resume using quarterly images in Q1
+FROM cimg/%%PARENT%%:2022.11
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 


### PR DESCRIPTION
Respin due to CVE
