### PR TITLE
add symlink to a common truststore

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,6 +22,8 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 		sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/jdk-%%VERSION_MAJOR%%; \
 	fi && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/* /usr/bin/ && \
+	sudo mkdir -p /etc/ssl/certs/java/cacerts && \
+	sudo ln -s ${JAVA_HOME}/lib/security/cacerts /etc/ssl/certs/java/cacerts && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \


### PR DESCRIPTION
Closes #130 

this implements a symlink that is present on many distros and acts as a more common truststore path to help support users

provided as a solution [here](https://stackoverflow.com/questions/62991314/adding-ssl-certificate-when-using-google-jib-and-kubernetes/62998403#62998403)

