### PR TITLE
feat: adds automated workflow for openjdk version updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,22 @@ version: 2.1
 orbs:
   cimg: circleci/cimg@0.3.0
 
+parameters:
+  cron:
+    type: boolean
+    default: false
+
 workflows:
+  automated-wf:
+    when: << pipeline.parameters.cron >>
+    jobs:
+      - check-feed:
+          context:
+            - cimg-publishing
+
   main-wf:
+    when:
+      not: << pipeline.parameters.cron >>
     jobs:
       - cimg/build-and-deploy:
           name: "Staging"
@@ -24,3 +38,44 @@ workflows:
               only:
                 - main
           context: cimg-publishing
+
+jobs:
+  check-feed:
+    docker:
+      - image: cimg/base:2023.01
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "f8:07:0f:f6:b5:eb:57:ae:be:4d:2f:2d:be:70:8f:ff"
+      - run:
+          name: SSH config to pull and push project
+          command: |
+            ssh-add -D
+            ssh-add ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff
+            ssh-keygen -f ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff -y > ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff.pub
+            echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch secops+cpe-image-bot@circleci.com" > ~/.ssh/allowed_signers
+      - run:
+          name: Run git config
+          command: |
+            cat \<<'EOF' >> ~/githelper.sh
+              #!/usr/bin/env bash
+              echo username=$GIT_USERNAME
+              echo password=$IMAGE_BOT_TOKEN
+            EOF
+
+            git config --global user.email "secops+cpe-image-bot@circleci.com"
+            git config --global user.name "cpe-image-bot"
+            git config --global user.signingkey "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch"
+            git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+            git config --global url."https://github.com".insteadOf ssh://git@github.com
+            git config --global url."https://github.com/".insteadOf git@github.com:
+            git config --global credential.helper "/bin/bash ~/githelper.sh"
+            git config --global gpg.format ssh
+            git config --global commit.gpgsign true
+            git submodule sync
+      - run:
+          name: Run version update script
+          command: |
+            sudo chmod +x openJDKFeed.sh
+            ./openJDKFeed.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   cimg: circleci/cimg@0.3.0
+  slack: circleci/slack@4.12.1
 
 parameters:
   cron:
@@ -29,6 +30,12 @@ workflows:
             branches:
               ignore:
                 - main
+          post-steps:
+            - slack/notify:
+                branch_pattern: release-v.+
+                event: pass
+                mentions: "@jalexchen"
+                template: basic_success_1
           context: cimg-publishing
       - cimg/build-and-deploy:
           name: "Deploy"
@@ -37,6 +44,12 @@ workflows:
             branches:
               only:
                 - main
+          post-steps:
+            - slack/notify:
+                branch_pattern: main
+                event: fail
+                mentions: "@images"
+                template: basic_fail_1
           context: cimg-publishing
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,4 +78,5 @@ jobs:
           name: Run version update script
           command: |
             sudo chmod +x openJDKFeed.sh
+            git submodule update --init --recursive
             ./openJDKFeed.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   cimg: circleci/cimg@0.3.0
   slack: circleci/slack@4.12.1
+  gh: circleci/github-cli@2.2.0
 
 parameters:
   cron:
@@ -87,6 +88,8 @@ jobs:
             git config --global gpg.format ssh
             git config --global commit.gpgsign true
             git submodule sync
+      - gh/setup:
+          token: IMAGE_BOT_TOKEN
       - run:
           name: Run version update script
           command: |

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2023.01
+FROM cimg/%%PARENT%%:2023.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -4,19 +4,12 @@ shopt -s extglob
 
 vers=()
 
-git pull origin main
-
-echo "Initializing submodule..."
-git submodule update --init --recursive
-cd shared || exit
-git checkout feat/version-checking
-if [ -f automated-updates.sh ]; then
-  source automated-updates.sh
+if [ -f shared/automated-updates.sh ]; then
+  source shared/automated-updates.sh
 else
   echo "Check if submodule was loaded; automated-updates.sh is missing"
   exit 1
 fi
-cd ..
 
 versionCleaner () {
   local dirtyVersion=$1

--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+shopt -s extglob
+
+vers=()
+
+git pull origin main
+
+echo "Initializing submodule..."
+git submodule update --init --recursive
+cd shared || exit
+git checkout feat/version-checking
+if [ -f automated-updates.sh ]; then
+  source automated-updates.sh
+else
+  echo "Check if submodule was loaded; automated-updates.sh is missing"
+  exit 1
+fi
+cd ..
+
+versionCleaner () {
+  local dirtyVersion=$1
+
+  case $dirtyVersion in
+    jdk8u+([0-9]*))
+      buildVersion=$(cut -d "-" -f2 <<< "${dirtyVersion}")
+      generateVersions "$(cut -d "-" -f1 <<< "${dirtyVersion}")"
+      newFullVersion=$(echo "$newVersion" | trimmer "j d k" | sed -r 's/u/.0./g')
+      newVersion=${newFullVersion}
+      ;;
+    jdk-+([0-9])*)
+      generateVersions "$(cut -d "-" -f2 <<< "${dirtyVersion}")"
+      buildVersion=$(cut -d "+" -f2 <<< "${newVersion}")
+      newVer=${newVersion%+*}
+      if [[ $newVer =~ ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]) ]]; then
+        newVersionExtended=${newVersion%+*}
+        newVersion=${newVer%.*}
+      else
+        newVersion=$newVer
+      fi
+      ;;
+    *)
+      echo "Nothing to clean"
+      return 1
+    ;;
+  esac
+
+  majorMinor=${newVersion%.*}
+
+  if [[ $majorMinor =~ ([0-9]+\.[0-9]+\.[0-9]) ]]; then
+    majorMinor=${majorMinor%.*}
+  fi
+}
+
+buildParameter() {
+  local newVersionString=$1
+
+  if [[ $newVersionString =~ ^8.0 ]]; then
+    export builtParam="#https://github.com/adoptium/temurin8-binaries/releases/download/$dirtyVersion/OpenJDK8U-jdk_x64_linux_hotspot_$newFullVersion$buildVersion.tar.gz"
+  else
+    export builtParam="#https://github.com/adoptium/temurin$jdkver-binaries/releases/download/jdk-$newVersionString%2B$buildVersion/OpenJDK${jdkver}U-jdk_x64_linux_hotspot_${newVersionString}_$buildVersion.tar.gz"
+  fi
+}
+
+
+getGradleVersion() {
+  local templateFile=$1
+
+  RSS_URL="https://github.com/gradle/gradle/releases.atom"
+  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(link)' | grep -E 'v[0-9]' | cut -d "/" -f9 | tr -d "\"")
+
+  for version in $VERSIONS; do
+    if [[ $version =~ ^v[0-9]+(\.[0-9]+)*$ ]]; then
+      generateVersions "$(cut -d "v" -f2 <<< "${version}")"
+      generateSearchTerms "GRADLE_VERSION=" "$templateFile" '"\\" " "'
+      # because Gradle (and Go) do not track the patch version if it ends in .0, this is necessary to account for the download URL
+      if [[ ${newVersion:(-2)} == ".0" ]]; then
+        newVersion=${newVersion%.*}
+      fi
+      replaceVersions "GRADLE_VERSION=" "$SEARCH_TERM" true
+    fi
+  done
+}
+
+
+getMavenVersion() {
+  local templateFile=$1
+
+  RSS_URL="https://github.com/apache/maven/tags.atom"
+  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
+
+  for version in $VERSIONS; do
+    if [[ $version =~ ^[0-9]+(\.[0-9]+)*$  || $version =~ ^maven-[0-9]+(\.[0-9]+)*$ ]]; then
+      generateVersions "$(cut -d "-" -f2 <<< "${version}")"
+      generateSearchTerms "MAVEN_VERSION=" "$templateFile" '"\\" " "'
+      replaceVersions "MAVEN_VERSION=" "$SEARCH_TERM" true
+    fi
+  done
+}
+
+getSbtVersion () {
+  local templateFile=$1
+
+  RSS_URL="https://github.com/sbt/sbt/tags.atom"
+  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
+
+  for version in $VERSIONS; do
+    if [[ $version =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+      generateVersions "$version"
+      generateSearchTerms "SBT_VERSION=" "$templateFile" '"\\" " "'
+      replaceVersions "SBT_VERSION=" "$SEARCH_TERM" true
+    fi
+  done
+}
+
+getOpenJDKVersion() {
+  echo "Getting latest Gradle version..."
+  getGradleVersion "Dockerfile.template"
+
+  echo "Getting latest Maven version..."
+  getMavenVersion "Dockerfile.template"
+
+  echo "Getting latest sbt version..."
+  getSbtVersion "Dockerfile.template"
+
+  # add or remove tracked openjdk versions here
+  openjdk_vers=(8 11 16 17 18 19)
+
+  for jdkver in "${openjdk_vers[@]}"; do
+    RSS_URL="https://github.com/adoptium/temurin${jdkver}-binaries/tags.atom"
+    VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
+
+    for version in $VERSIONS; do
+      if [[ $version =~ jdk8u+([0-9])* || $version =~ jdk-[0-9]([0-9])* ]]; then
+        versionCleaner "$version"
+        if [ "$(eval echo $?)" -eq 1 ]; then
+          continue
+        fi
+
+        if [[ $newVersionExtended == "$newVersion" ]]; then
+          buildParameter "$newVersionExtended"
+        else
+          buildParameter "$newVersion"
+        fi
+
+        generateSearchTerms "JAVA_VERSION" "$majorMinor/Dockerfile"
+        directoryCheck "$majorMinor" "$SEARCH_TERM" "$builtParam"
+
+        if [[ $(eval echo $?) -eq 0 ]]; then
+          generateVersionString "$newVersion" "$builtParam"
+        fi
+      fi
+    done
+  done
+}
+
+getOpenJDKVersion
+
+if [ -n "${vers[*]}" ]; then
+  echo "Included version updates: ${vers[*]}"
+  echo "Running release script"
+  ./shared/release.sh "${vers[@]}"
+else
+  echo "No new version updates"
+  exit 0
+fi


### PR DESCRIPTION
this PR adds a new check-feeds job to the config, which is intended to be used with scheduled pipelines
this adds openJDKFeed.sh, which will find updated versions of openjdk and it's associated binary URL, then run the release script

- adds slack notification
- adds gh PR workflow