### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,8 +15,16 @@ ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}
 
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
 	JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION" | cut -d '.' -f 1) && \
-	JAVA_BUILD=$(curl -s "https://api.github.com/repos/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases" | jq ".[] | select(.tag_name | startswith(\"jdk-${JAVA_VERSION}+\")) | .tag_name | split(\"+\")[1]" | tr -d '"') && \
-	URL="https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_${ARCH}_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD}.tar.gz" && \
+	JAVA_PATCH_VERSION=$(echo "$JAVA_VERSION" | cut -d '.' -f 3) && \
+	if [ "$JAVA_MAJOR_VERSION" = "8" ]; then \
+		JAVA_BUILD=$(curl -s "https://api.github.com/repos/adoptium/temurin8-binaries/releases" | jq ".[] | select(.tag_name | startswith(\"jdk8u${JAVA_PATCH_VERSION}\")) | .tag_name" | tr -d '"'); \
+		JAVA_BUILD="${JAVA_BUILD/jdk8u/}"; \
+		JAVA_BUILD_SANITISED="${JAVA_BUILD//-/}"; \
+		URL="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u${JAVA_BUILD}/OpenJDK8U-jdk_${ARCH}_linux_hotspot_8u${JAVA_BUILD_SANITISED}.tar.gz"; \
+	else \
+		JAVA_BUILD=$(curl -s "https://api.github.com/repos/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases" | jq ".[] | select(.tag_name | startswith(\"jdk-${JAVA_VERSION}+\")) | .tag_name | split(\"+\")[1]" | tr -d '"'); \
+		URL="https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_${ARCH}_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD}.tar.gz"; \
+	fi && \
 	curl -sSL -o java.tar.gz "${URL}" && \
 	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \
 	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -36,7 +36,7 @@ RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
 	java --version || java -version && \
 	javac --version || javac -version
 
-ENV MAVEN_VERSION=3.9.1 \
+ENV MAVEN_VERSION=3.9.3 \
 	PATH=/opt/apache-maven/bin:$PATH
 RUN dl_URL="https://www.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
 	curl -sSL --fail --retry 3 $dl_URL -o apache-maven.tar.gz && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,8 +14,9 @@ ENV JAVA_VERSION %%MAIN_VERSION%%
 ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}
 
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
-	JAVA_BUILD = $(url -s "https://api.github.com/repos/adoptium/temurin${VERSION_MAJOR}-binaries/releases" | jq '.[] | select(.tag_name | startswith("jdk-${JAVA_VERSION}}+")) | .tag_name | split("+")[1]') && \
-	URL = "https://github.com/adoptium/temurin${VERSION_MAJOR}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD}/OpenJDK16U-jdk_${ARCH}_linux_hotspot_{JAVA_VERSION}_${JAVA_BUILD}.tar.gz" && \
+	JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION" | cut -d '.' -f 1) && \
+	JAVA_BUILD=$(curl -s "https://api.github.com/repos/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases" | jq ".[] | select(.tag_name | startswith(\"jdk-${JAVA_VERSION}+\")) | .tag_name | split(\"+\")[1]" | tr -d '"') && \
+	URL="https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_${ARCH}_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD}.tar.gz" && \
 	curl -sSL -o java.tar.gz "${URL}" && \
 	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \
 	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,15 +6,17 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2023.04
+FROM cimg/%%PARENT%%:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 ENV JAVA_VERSION %%MAIN_VERSION%%
-ENV URL %%PARAM1%%
 ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSION}
 
-RUN curl -sSL -o java.tar.gz "${URL}" && \
+RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
+	JAVA_BUILD = $(url -s "https://api.github.com/repos/adoptium/temurin${VERSION_MAJOR}-binaries/releases" | jq '.[] | select(.tag_name | startswith("jdk-${JAVA_VERSION}}+")) | .tag_name | split("+")[1]') && \
+	URL = "https://github.com/adoptium/temurin${VERSION_MAJOR}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD}/OpenJDK16U-jdk_${ARCH}_linux_hotspot_{JAVA_VERSION}_${JAVA_BUILD}.tar.gz" && \
+	curl -sSL -o java.tar.gz "${URL}" && \
 	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \
 	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \
 	rm java.tar.gz && \

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=openjdk
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
This PR adds multi architecture images with arm64 support

# Reasons
Enables arm64 support using the updating tooling in cimg-shared and cimg-orb and arch checks.

This PR also adds automatic resolving of the full java version tag including build number, so a URL no longer has to be passed as a parameter, just the version (e.g., `20.0.1`). This works for all Java LTS versions that we support.

Test build of all current LTS versions: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-openjdk/935/workflows/0f9b625d-4bc6-4fa5-a8dd-146053864195/jobs/1193

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)