### PR TITLE
Track OpenJDK 21 in openJDKFeed.sh

### DIFF
--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -105,7 +105,7 @@ getOpenJDKVersion() {
   getJava8
 
   # add or remove tracked openjdk versions here
-  openjdk_vers=(11 16 17 18 19 20)
+  openjdk_vers=(11 16 17 18 19 20 21)
 
   for jdkver in "${openjdk_vers[@]}"; do
     JAVA_VERSIONS=$(curl -s "https://api.github.com/repos/adoptium/temurin${jdkver}-binaries/releases" | jq -r ".[] | select(.tag_name | test(\"jdk-\")) | .tag_name")


### PR DESCRIPTION
# Description
Adds 21 that was missing.

# Reasons
A new version of 21 (21.0.1) has been available since October 28, 2023 but hasn't been released.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
