### PR TITLE
[PROV-NOTICKET] fix: mill version not being updated correctly

### DIFF
--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -69,8 +69,8 @@ getMillVersion () {
   for version in $VERSIONS; do
     if [[ $version =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
       generateVersions "$version"
-      generateSearchTerms "SBT_VERSION=" "$templateFile" '"\\" " "'
-      replaceVersions "SBT_VERSION=" "$SEARCH_TERM" true
+      generateSearchTerms "MILL_VERSION=" "$templateFile"
+      replaceVersions "MILL_VERSION=" "$SEARCH_TERM" true
     fi
   done
 }


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
mill was replacing the sbt version. building java 21 broke because only the latest versions of mill implemented support

# Checklist

Please check through the following before opening your PR. Thank you!

- [] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
