### PR TITLE
Update cimg orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.6.1
+  cimg: circleci/cimg@0.6.2
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
@@ -14,7 +14,8 @@ workflows:
   automated-wf:
     when: << pipeline.parameters.cron >>
     jobs:
-      - check-feed:
+      - cimg/update:
+          update-script: openJDKFeed.sh
           context:
             - cpe-image-bot-github-creds
   main-wf:
@@ -54,49 +55,3 @@ workflows:
                 event: fail
                 mentions: "@images"
                 template: basic_fail_1
-
-jobs:
-  check-feed:
-    docker:
-      - image: cimg/base:current
-    resource_class: small
-    steps:
-      - checkout
-      - run:
-          name: SSH config to pull and push project
-          command: |
-            echo "$IMAGE_BOT_SIGNING_KEY_B64" | base64 -d > ~/.ssh/id_signing_key
-            chmod 600 ~/.ssh/id_signing_key
-
-            ssh-add -D
-            ssh-add ~/.ssh/id_signing_key
-            ssh-keygen -f ~/.ssh/id_signing_key -y > ~/.ssh/id_signing_key.pub
-            echo "$(cat ~/.ssh/id_signing_key.pub) $IMAGE_BOT_EMAIL" > ~/.ssh/allowed_signers
-
-      - run:
-          name: Run git config
-          command: |
-            cat \<<'EOF' >> ~/githelper.sh
-              #!/usr/bin/env bash
-              echo username=$GIT_USERNAME
-              echo password=$IMAGE_BOT_TOKEN
-            EOF
-
-            git config --global user.email "$IMAGE_BOT_EMAIL"
-            git config --global user.name "$GIT_USERNAME"
-            git config --global user.signingkey "$(cat ~/.ssh/id_signing_key.pub)"
-            git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
-            git config --global url."https://github.com".insteadOf ssh://git@github.com
-            git config --global url."https://github.com/".insteadOf git@github.com:
-            git config --global credential.helper "/bin/bash ~/githelper.sh"
-            git config --global gpg.format ssh
-            git config --global commit.gpgsign true
-            git submodule sync
-      - gh/setup:
-          token: IMAGE_BOT_TOKEN
-      - run:
-          name: Run version update script
-          command: |
-            sudo chmod +x openJDKFeed.sh
-            git submodule update --init --recursive
-            ./openJDKFeed.sh


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.

Update to the latest cimg/orb & use new update job instead of check-feed.

Tested that the orb works here: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-openjdk/1372/workflows/72b03d27-776c-4fae-bf3f-94c2e653600a/jobs/1635 (this was expected to fail)

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
