### PR TITLE
Ignore beta java versions when updating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ workflows:
       - cimg/update:
           update-script: openJDKFeed.sh
           context:
+            - slack-notification-access-token
+            - slack-cimg-notifications
             - cpe-image-bot-github-creds
   main-wf:
     when:
@@ -31,7 +33,10 @@ workflows:
             branches:
               ignore:
                 - main
-          context: cimg-docker-image-building
+          context: 
+            - slack-notification-access-token
+            - slack-cimg-notifications
+            - cimg-docker-image-building
           post-steps:
             - slack/notify:
                 branch_pattern: main
@@ -47,6 +52,8 @@ workflows:
               only:
                 - main
           context:
+            - slack-notification-access-token
+            - slack-cimg-notifications
             - cimg-docker-image-building
             - cimg-docker-image-publishing
           post-steps:

--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -78,6 +78,12 @@ getMillVersion () {
 getJava8 () {
   JAVA_VERSIONS=$(curl -s "https://api.github.com/repos/adoptium/temurin8-binaries/releases" | jq -r ".[] | select(.tag_name | test(\"jdk8u[^-]\")) | .tag_name");
   for version in $JAVA_VERSIONS; do
+
+    if [[ $version == *"-beta"* ]]; then
+      echo "Skipping beta version $version"
+      break
+    fi
+
     patch=$(echo "$version" | cut -d 'u' -f2 | cut -d '-' -f1)
     generateSearchTerms "JAVA_VERSION" "8.0/Dockerfile"
     versionEqual "$patch" "${SEARCH_TERM#*.*.}"


### PR DESCRIPTION
# Description
A brief description of the changes in this PR.

The auto update bot PR has been failing because it detected a beta java versions that it's not setup to handle. This updates the script to ignore beta versions. 

This was tested here: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-openjdk/1411/workflows/f5f991fd-79ae-4c94-a19a-ffc01eccad00/jobs/1674?invite=true#step-107-1758_42

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
