### PR TITLE
Track latest OpenJDK release versions

### DIFF
--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -111,7 +111,7 @@ getOpenJDKVersion() {
   getJava8
 
   # add or remove tracked openjdk versions here
-  openjdk_vers=(11 16 17 18 19 20 21)
+  openjdk_vers=(11 16 17 18 19 20 21 22 23)
 
   for jdkver in "${openjdk_vers[@]}"; do
     JAVA_VERSIONS=$(curl -s "https://api.github.com/repos/adoptium/temurin${jdkver}-binaries/releases" | jq -r ".[] | select(.tag_name | test(\"jdk-\")) | .tag_name")


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Start tracking releases of OpenJDK 22 and 23 (addressing #205).

# Reasons

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
