### PR TITLE
Similar to JDK 8, skip when release names contain -beta

### DIFF
--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -117,6 +117,10 @@ getOpenJDKVersion() {
     JAVA_VERSIONS=$(curl -s "https://api.github.com/repos/adoptium/temurin${jdkver}-binaries/releases" | jq -r ".[] | select(.tag_name | test(\"jdk-\")) | .tag_name")
 
     for version in $JAVA_VERSIONS; do
+      if [[ $version == *"-beta"* ]]; then
+        echo "Skipping beta version $version"
+        continue
+      fi
       if [[ $version =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9] ]]; then
         continue
       fi


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
