### PR TITLE
Always provide a MAJOR.MINOR version number

### DIFF
--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -126,6 +126,11 @@ getOpenJDKVersion() {
       fi
       JAVA_VERSION=$(echo "$version" | cut -d '-' -f 2 | cut -d '+' -f 1)
       JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d '.' -f 1)
+      if [[ "$JAVA_VERSION" = "$JAVA_MAJOR" ]]; then
+        # If the full version matches the major, provide a fake .0 minor version to the full version.
+        # Otherwise, this causes downstream weirdness in the rest of the pile of scripts.
+        JAVA_VERSION="$JAVA_MAJOR.0"
+      fi
       generateSearchTerms "JAVA_VERSION" "$JAVA_MAJOR.0/Dockerfile"
       versionEqual "$JAVA_VERSION" "$SEARCH_TERM"
       if [[ $(eval echo $?) -eq 0 ]]; then


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
The shared release scripting system makes some assumptions about the shape of the version numbers that will be provided, and the OpenJDK 23 release does not fit that assumption currently. This PR appends a ".0" to the full Java version in the case that the full version and the major version match (i.e. if the full version is 23, as is the case here, and the major version is 23, the full version becomes 23.0).

# Reasons
To successfully release OpenJDK 22 and 23 images, this deficiency needs to be corrected.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
