### PR TITLE
Add Dockerfiles for JDK 24.0.1

### DIFF
--- a/24.0/Dockerfile
+++ b/24.0/Dockerfile
@@ -6,11 +6,11 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2024.02
+FROM cimg/base:2024.02
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
-ENV JAVA_VERSION=%%MAIN_VERSION%%
+ENV JAVA_VERSION=24.0.1
 ENV JAVA_HOME=/usr/local/jdk-${JAVA_VERSION}
 
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
@@ -30,7 +30,7 @@ RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
 	sudo tar -xzf java.tar.gz --strip-components=1 -C /usr/local/jdk-${JAVA_VERSION} && \
 	rm java.tar.gz && \
 	if [[ "$JAVA_VERSION" == *"0.0"* ]]; then \
-		sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/jdk-%%VERSION_MAJOR%%; \
+		sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/jdk-24; \
 	fi && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/* /usr/bin/ && \
 	sudo mkdir -p /etc/ssl/certs/java/cacerts && \

--- a/24.0/browsers/Dockerfile
+++ b/24.0/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/openjdk:24.0.1-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+# Install a single version of Firefox. This isn't intended to be a regularly
+# updated thing. Instead, if this version of Firefox isn't what the end user
+# wants they should install a different version via the Browser Tools Orb.
+#
+# Canonical made a major technology change in how Firefox is installed from
+# Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
+	sudo apt-get install --no-install-recommends --yes firefox && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	firefox --version
+
+# Install a single version of Google Chrome Stable. This isn't intended to be a
+# regularly updated thing. Instead, if this version of Chrome isn't what the
+# end user wants they should install a different version via the Browser Tools
+# Orb.
+RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+	sudo apt-get update && \
+	sudo apt-get install google-chrome-stable && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/24.0/node/Dockerfile
+++ b/24.0/node/Dockerfile
@@ -1,0 +1,21 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/openjdk:24.0.1
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="arm64" && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.19
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(8.0.442 11.0.26 17.0.14 21.0.6 23.0.2)
+GEN_CHECK=(24.0.1#https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24.0.1%2B9/OpenJDK24U-jdk_x64_linux_hotspot_24.0.1_9.tar.gz)

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,18 +4,6 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 8.0/Dockerfile -t cimg/openjdk:8.0.442 -t cimg/openjdk:8.0 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 8.0/node/Dockerfile -t cimg/openjdk:8.0.442-node -t cimg/openjdk:8.0-node --push .
-docker buildx build --platform=linux/amd64 --file 8.0/browsers/Dockerfile -t cimg/openjdk:8.0.442-browsers -t cimg/openjdk:8.0-browsers --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 11.0/Dockerfile -t cimg/openjdk:11.0.26 -t cimg/openjdk:11.0 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 11.0/node/Dockerfile -t cimg/openjdk:11.0.26-node -t cimg/openjdk:11.0-node --push .
-docker buildx build --platform=linux/amd64 --file 11.0/browsers/Dockerfile -t cimg/openjdk:11.0.26-browsers -t cimg/openjdk:11.0-browsers --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 17.0/Dockerfile -t cimg/openjdk:17.0.14 -t cimg/openjdk:17.0 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 17.0/node/Dockerfile -t cimg/openjdk:17.0.14-node -t cimg/openjdk:17.0-node --push .
-docker buildx build --platform=linux/amd64 --file 17.0/browsers/Dockerfile -t cimg/openjdk:17.0.14-browsers -t cimg/openjdk:17.0-browsers --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 21.0/Dockerfile -t cimg/openjdk:21.0.6 -t cimg/openjdk:21.0 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 21.0/node/Dockerfile -t cimg/openjdk:21.0.6-node -t cimg/openjdk:21.0-node --push .
-docker buildx build --platform=linux/amd64 --file 21.0/browsers/Dockerfile -t cimg/openjdk:21.0.6-browsers -t cimg/openjdk:21.0-browsers --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 23.0/Dockerfile -t cimg/openjdk:23.0.2 -t cimg/openjdk:23.0 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 23.0/node/Dockerfile -t cimg/openjdk:23.0.2-node -t cimg/openjdk:23.0-node --push .
-docker buildx build --platform=linux/amd64 --file 23.0/browsers/Dockerfile -t cimg/openjdk:23.0.2-browsers -t cimg/openjdk:23.0-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 24.0/Dockerfile -t cimg/openjdk:24.0.1 -t cimg/openjdk:24.0 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 24.0/node/Dockerfile -t cimg/openjdk:24.0.1-node -t cimg/openjdk:24.0-node --push .
+docker buildx build --platform=linux/amd64 --file 24.0/browsers/Dockerfile -t cimg/openjdk:24.0.1-browsers -t cimg/openjdk:24.0-browsers --push .


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
This PR adds Dockerfiles for JDK 24.0.1.

This PR also upgrades to Gradle 8.14 that supports JDK 24 in the `Dockerfile.template`.

# Reasons
See gh-224

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
