### PR TITLE
Update feed and template to work better with modern urls

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,8 +22,15 @@ RUN [[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="aarch64" && \
 		JAVA_BUILD_SANITISED="${JAVA_BUILD//-/}"; \
 		URL="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u${JAVA_BUILD}/OpenJDK8U-jdk_${ARCH}_linux_hotspot_8u${JAVA_BUILD_SANITISED}.tar.gz"; \
 	else \
-		JAVA_BUILD=$(curl -s "https://api.github.com/repos/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases" | jq "limit(1; .[] | select(.tag_name | startswith(\"jdk-${JAVA_VERSION}+\"))) | .tag_name | split(\"+\")[1]" | tr -d '"'); \
-		URL="https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD%.*}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_${ARCH}_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD%.*}.tar.gz"; \
+		if [ "$JAVA_VERSION" = "$JAVA_MAJOR_VERSION".0 ]; then \
+			START_WITH_VERSION=${JAVA_MAJOR_VERSION}; \
+			JAVA_SEARCH=${JAVA_MAJOR_VERSION}; \
+		else \
+			START_WITH_VERSION=${JAVA_VERSION}; \
+			JAVA_SEARCH=${JAVA_VERSION}; \
+		fi && \
+		JAVA_BUILD=$(curl -s "https://api.github.com/repos/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases" | jq "limit(1; .[] | select(.tag_name | startswith(\"jdk-${START_WITH_VERSION}+\"))) | .tag_name | split(\"+\")[1]" | tr -d '"'); \
+		URL="https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${JAVA_SEARCH}%2B${JAVA_BUILD%.*}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_${ARCH}_linux_hotspot_${JAVA_SEARCH}_${JAVA_BUILD%.*}.tar.gz"; \
 	fi && \
 	curl -sSL -o java.tar.gz "${URL}" && \
 	sudo mkdir /usr/local/jdk-${JAVA_VERSION} && \

--- a/openJDKFeed.sh
+++ b/openJDKFeed.sh
@@ -21,10 +21,12 @@ getGradleVersion() {
     if [[ $version =~ ^v[0-9]+(\.[0-9]+)*$ ]]; then
       generateVersions "$(cut -d "v" -f2 <<< "${version}")"
       generateSearchTerms "GRADLE_VERSION=" "$templateFile" '"\\" " "'
+
+      # THIS IS NOT TRUE; LETTING COMMENTED FOR NOW IN CASE IS REQUIRED
       # because Gradle (and Go) do not track the patch version if it ends in .0, this is necessary to account for the download URL
-      if [[ ${newVersion:(-2)} == ".0" ]]; then
-        newVersion=${newVersion%.*}
-      fi
+      # if [[ ${newVersion:(-2)} == ".0" ]]; then
+      #   newVersion=${newVersion%.*}
+      # fi
       replaceVersions "GRADLE_VERSION=" "$SEARCH_TERM" true
     fi
   done


### PR DESCRIPTION
The automatic feed has two problems now:
- The feed is removing the patch version when is a zero from gradle version, may be the URLs worked that way in the past, but it is not the case anymore, I'm restoring the zero to make it work
- Temurin releases don't put the full version on the release name when it is a x.0.0, this generates a conflict with the url generated in the template as it is adding an extra zero. I added a condition to generate the URL correctly depending if the version has x.0.0 or not